### PR TITLE
feat: Add API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Dependências
+/node_modules/
+
+# Compilados TypeScript
+/dist/
+/build/
+/coverage/
+
+# Arquivos de log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# IDEs e editores
+.idea/
+.vscode/
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+
+# Sistemas operacionais
+.DS_Store
+Thumbs.db
+
+# Ambiente
+.env
+.env.*
+
+# Arquivos de lock (ignorar o package-lock.json conforme solicitado)
+package-lock.json
+pnpm-lock.yaml
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -1,2 +1,148 @@
-# test-otsra
-Test Repository
+# Golden Raspberry – API de Pior Filme (TypeScript)
+
+![Node.js](https://img.shields.io/badge/Node.js-%3E%3D20.x-green?logo=node.js)
+![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue?logo=typescript)
+![License](https://img.shields.io/badge/License-MIT-lightgrey)
+
+API RESTful em **nível 2 de maturidade Richardson** que carrega automaticamente a lista de indicados e vencedores do prêmio _Framboesa de Ouro_ (pior filme) a partir de um arquivo CSV e disponibiliza consultas em **SQLite em memória**.
+
+> ✅ **Sem dependências externas** — basta Node 20+ e `npm`.
+
+---
+
+## Índice
+
+1. [Características](#características)
+2. [Pré‑requisitos](#pré-requisitos)
+3. [Instalação](#instalação)
+4. [Uso](#uso)
+
+   1. [Executar em desenvolvimento](#executar-em-desenvolvimento)
+   2. [Compilar para produção](#compilar-para-produção)
+
+5. [Contrato da API](#contrato-da-api)
+6. [Atualizando o CSV](#atualizando-o-csv)
+7. [Testes](#testes)
+8. [Estrutura do projeto](#estrutura-do-projeto)
+9. [Licença](#licença)
+
+---
+
+## Características
+
+- **TypeScript** + **ES Modules**: código moderno, tipado e compatível com ESM.
+- **Express + TypeORM**: ORM simples apontando para SQLite em memória (`:memory:`).
+- **Importação de CSV** na inicialização (ponto‑e‑vírgula como delimitador).
+- **Endpoints REST** para filmes e estatísticas de produtores.
+- **Testes de integração** com Jest + SuperTest.
+
+## Pré‑requisitos
+
+| Ferramenta | Versão | Observação                       |
+| ---------- | ------ | -------------------------------- |
+| Node.js    | ≥ 20.x | Inclui suporte a ESM sem _flag_. |
+| npm        | ≥ 10.x | Instalado junto com Node         |
+
+> 💡 **Dica Windows:** se aparecer erro nativo ao instalar `sqlite3`, execute `npm i --platform=win32 --arch=x64 sqlite3` ou use `better-sqlite3`.
+
+## Instalação
+
+Clone o repositório e instale as dependências:
+
+```bash
+git clone https://github.com/FelipeCararo/test-otsra.git
+cd test-otsra
+npm i
+```
+
+## Uso
+
+### Executar em desenvolvimento
+
+```bash
+npm run dev
+```
+
+- Servidor inicia em **[http://localhost:3000](http://localhost:3000)**.
+- Qualquer mudança em `src/**` recarrega a aplicação (`tsx watch`).
+
+### Compilar para produção
+
+```bash
+npm run build      # gera dist/
+npm start          # executa node dist/index.js
+```
+
+> Para alterar a porta em produção use `PORT=8080 npm start`.
+
+## Contrato da API
+
+| Método  | Rota                   | Descrição                                                                 | Exemplo de resposta                    |
+| ------- | ---------------------- | ------------------------------------------------------------------------- | -------------------------------------- |
+| **GET** | `/movies`              | Lista todos os filmes (suporta `?year=1985&winner=true` _WIP_)            | Array de objetos `Movie`               |
+| **GET** | `/movies/:id`          | Busca filme por ID                                                        | Objeto `Movie` ou **404**              |
+| **GET** | `/producers/intervals` | Estatística de produtores com menores e maiores intervalos entre vitórias | `{ min: Interval[], max: Interval[] }` |
+
+### Exemplo `/producers/intervals`
+
+```json
+{
+  "min": [
+    {
+      "producer": "Bo Derek",
+      "interval": 1,
+      "previousWin": 1984,
+      "followingWin": 1985
+    }
+  ],
+  "max": [
+    {
+      "producer": "Alan Ladd Jr.",
+      "interval": 15,
+      "previousWin": 1985,
+      "followingWin": 2000
+    }
+  ]
+}
+```
+
+## Atualizando o CSV
+
+1. Abra **`csv/Movielist.csv`** e cole novos registros seguindo o cabeçalho:
+
+```csv
+year;title;studios;producers;winner
+```
+
+2. Salve em **UTF‑8** para preservar acentuação.
+3. Reinicie a aplicação — o banco é recriado a cada subida.
+
+## Testes
+
+```bash
+npm t
+```
+
+- `jest --runInBand` executa **apenas integração** (sem mocks).
+- Um banco em memória dedicado é criado e destruído automaticamente.
+
+## Estrutura do projeto
+
+```text
+.
+├── csv/Movielist.csv           # base de dados de filmes
+├── src
+│   ├── index.ts              # bootstrap (CSV → DB → HTTP)
+│   ├── app.ts                # Express + rotas
+│   ├── db.ts                 # DataSource SQLite em memória
+│   ├── entities/             # TypeORM entities
+│   ├── repositories/         # Abstrações de repositório
+│   ├── services/             # Lógica de negócio (intervalos)
+│   └── routes/               # Rotas REST
+└── test
+    └── movie.e2e.spec.ts     # testes de integração
+```
+
+## Licença
+
+[MIT](LICENSE) © 2025 — Felipe Cararo

--- a/csv/Movielist.csv
+++ b/csv/Movielist.csv
@@ -1,0 +1,207 @@
+year;title;studios;producers;winner
+1980;Can't Stop the Music;Associated Film Distribution;Allan Carr;yes
+1980;Cruising;Lorimar Productions, United Artists;Jerry Weintraub;
+1980;The Formula;MGM, United Artists;Steve Shagan;
+1980;Friday the 13th;Paramount Pictures;Sean S. Cunningham;
+1980;The Nude Bomb;Universal Studios;Jennings Lang;
+1980;The Jazz Singer;Associated Film Distribution;Jerry Leider;
+1980;Raise the Titanic;Associated Film Distribution;William Frye;
+1980;Saturn 3;Associated Film Distribution;Stanley Donen;
+1980;Windows;United Artists;Mike Lobell;
+1980;Xanadu;Universal Studios;Lawrence Gordon;
+1981;Mommie Dearest;Paramount Pictures;Frank Yablans;yes
+1981;Endless Love;Universal Studios, PolyGram;Dyson Lovell;
+1981;Heaven's Gate;United Artists;Joann Carelli;
+1981;The Legend of the Lone Ranger;Universal Studios, Associated Film Distribution;Walter Coblenz;
+1981;Tarzan, the Ape Man;MGM, United Artists;John Derek;
+1982;Inchon;MGM;Mitsuharu Ishii;yes
+1982;Annie;Columbia Pictures;Ray Stark;
+1982;Butterfly;Analysis Film Releasing;Matt Cimber;
+1982;Megaforce;20th Century Fox;Albert S. Ruddy;
+1982;The Pirate Movie;20th Century Fox;David Joseph;
+1983;The Lonely Lady;Universal Studios;Robert R. Weston;yes
+1983;Hercules;MGM, United Artists, Cannon Films;Yoram Globus and Menahem Golan;
+1983;Jaws 3-D;Universal Studios;Rupert Hitzig;
+1983;Stroker Ace;Warner Bros., Universal Studios;Hank Moonjean;
+1983;Two of a Kind;20th Century Fox;Roger M. Rothstein and Joe Wizan;
+1984;Bolero;Cannon Films;Bo Derek;yes
+1984;Cannonball Run II;Warner Bros.;Albert S. Ruddy;
+1984;Rhinestone;20th Century Fox;Marvin Worth and Howard Smith;
+1984;Sheena;Columbia Pictures;Paul Aratow;
+1984;Where the Boys Are '84;TriStar Pictures;Allan Carr;
+1985;Rambo: First Blood Part II;Columbia Pictures;Buzz Feitshans;yes
+1985;Fever Pitch;MGM, United Artists;Freddie Fields;
+1985;Revolution;Warner Bros.;Irwin Winkler;
+1985;Rocky IV;MGM, United Artists;Irwin Winkler and Robert Chartoff;
+1985;Year of the Dragon;MGM, United Artists;Dino De Laurentiis;
+1986;Howard the Duck;Universal Studios;Gloria Katz;yes
+1986;Under the Cherry Moon;Warner Bros.;Bob Cavallo, Joe Ruffalo and Steve Fargnoli;yes
+1986;Blue City;Paramount Pictures;William L. Hayward and Walter Hill;
+1986;Cobra;Warner Bros., Cannon Films;Yoram Globus and Menahem Golan;
+1986;Shanghai Surprise;MGM;John Kohn;
+1987;Leonard Part 6;Columbia Pictures;Bill Cosby;yes
+1987;Ishtar;Columbia Pictures;Warren Beatty;
+1987;Jaws: The Revenge;Universal Studios;Joseph Sargent;
+1987;Tough Guys Don't Dance;Cannon Films;Yoram Globus and Menahem Golan;
+1987;Who's That Girl;Warner Bros.;Rosilyn Heller and Bernard Williams;
+1988;Cocktail;Touchstone Pictures;Ted Field and Robert W. Cort;yes
+1988;Caddyshack II;Warner Bros.;Neil Canton, Jon Peters and Peter Guber;
+1988;Hot to Trot;Warner Bros.;Steve Tisch;
+1988;Mac and Me;Orion Pictures;R. J. Louis;
+1988;Rambo III;TriStar Pictures, Carolco Pictures;Buzz Feitshans;
+1989;Star Trek V: The Final Frontier;Paramount Pictures;Harve Bennett;yes
+1989;The Karate Kid Part III;Columbia Pictures;Jerry Weintraub;
+1989;Lock Up;TriStar Pictures, Carolco Pictures;Charles Gordon and Lawrence Gordon;
+1989;Road House;United Artists;Joel Silver;
+1989;Speed Zone;Orion Pictures;Murray Shostack;
+1990;The Adventures of Ford Fairlane;20th Century Fox;Steven Perry and Joel Silver;yes
+1990;Ghosts Can't Do It;Triumph Releasing;Bo Derek;yes
+1990;The Bonfire of the Vanities;Warner Bros.;Brian De Palma;
+1990;Graffiti Bridge;Warner Bros.;Randy Phillips and Craig Rice;
+1990;Rocky V;United Artists;Robert Chartoff and Irwin Winkler;
+1991;Hudson Hawk;TriStar Pictures;Joel Silver;yes
+1991;Cool as Ice;Universal Studios;Carolyn Pfeiffer and Lionel Wingram;
+1991;Dice Rules;Seven Arts Productions;Loucas George;
+1991;Nothing but Trouble;Warner Bros.;Lester Berman and Robert K. Weiss;
+1991;Return to the Blue Lagoon;Columbia Pictures;William A. Graham;
+1992;Shining Through;20th Century Fox;Carol Baum and Howard Rosenman;yes
+1992;The Bodyguard;Warner Bros.;Kevin Costner, Lawrence Kasdan and Jim Wilson;
+1992;Christopher Columbus: The Discovery;Warner Bros.;Alexander Salkind and Ilya Salkind;
+1992;Final Analysis;20th Century Fox;Paul Junger Witt, Charles Roven and Tony Thomas;
+1992;Newsies;Walt Disney Pictures;Michael Finnell;
+1993;Indecent Proposal;Paramount Pictures;Sherry Lansing;yes
+1993;Body of Evidence;MGM, United Artists;Dino De Laurentiis;
+1993;Cliffhanger;TriStar Pictures, Carolco Pictures;Renny Harlin and Alan Marshall;
+1993;Last Action Hero;Columbia Pictures;John McTiernan and Stephen J. Roth;
+1993;Sliver;Paramount Pictures;Robert Evans;
+1994;Color of Night;Hollywood Pictures;Buzz Feitshans and David Matalon;yes
+1994;North;Columbia Pictures, Castle Rock Entertainment;Rob Reiner and Alan Zweibel;
+1994;On Deadly Ground;Warner Bros.;A. Kitman Ho, Julius R. Nasso and Steven Seagal;
+1994;The Specialist;Warner Bros.;Jerry Weintraub;
+1994;Wyatt Earp;Warner Bros.;Kevin Costner, Lawrence Kasdan and Jim Wilson;
+1995;Showgirls;MGM, United Artists;Charles Evans and Alan Marshall;yes
+1995;Congo;Paramount Pictures;Kathleen Kennedy and Sam Mercer;
+1995;It's Pat;Touchstone Pictures;Charles B. Wessler;
+1995;The Scarlet Letter;Hollywood Pictures;Roland Joffé and Andrew G. Vajna;
+1995;Waterworld;Universal Studios;Kevin Costner, John Davis, Charles Gordon and Lawrence Gordon;
+1996;Striptease;Columbia Pictures, Castle Rock Entertainment;Andrew Bergman and Mike Lobell;yes
+1996;Barb Wire;PolyGram Filmed Entertainment, Gramercy Pictures;Todd Moyer, Mike Richardson and Brad Wyman;
+1996;Ed;Universal Studios;Rosalie Swedlin;
+1996;The Island of Dr. Moreau;New Line Cinema;Edward R. Pressman;
+1996;The Stupids;New Line Cinema, Savoy Pictures;Leslie Belzberg;
+1997;The Postman;Warner Bros.;Kevin Costner, Steve Tisch and Jim Wilson;yes
+1997;Anaconda;Columbia Pictures;Verna Harrah, Carole Little and Leonard Rabinowitz;
+1997;Batman & Robin;Warner Bros.;Peter MacGregor-Scott;
+1997;Fire Down Below;Warner Bros.;Julius R. Nasso and Steven Seagal;
+1997;Speed 2: Cruise Control;20th Century Fox;Jan de Bont, Steve Perry and Michael Peyser;
+1998;An Alan Smithee Film: Burn Hollywood Burn;Hollywood Pictures;Ben Myron and Joe Eszterhas;yes
+1998;Armageddon;Touchstone Pictures;Michael Bay and Jerry Bruckheimer;
+1998;The Avengers;Warner Bros.;Jerry Weintraub;
+1998;Godzilla;TriStar Pictures;Roland Emmerich and Dean Devlin;
+1998;Spice World;Columbia Pictures;Uri Fruchtan, Mark L. Rosen and Barnaby Thompson;
+1999;Wild Wild West;Warner Bros.;Jon Peters and Barry Sonnenfeld;yes
+1999;Big Daddy;Columbia Pictures;Sidney Ganis and Jack Giarraputo;
+1999;The Blair Witch Project;Artisan Entertainment;Robin Cowie and Gregg Hale;
+1999;The Haunting;DreamWorks;Susan Arthur, Donna Roth and Colin Wilson;
+1999;Star Wars: Episode I – The Phantom Menace;20th Century Fox;Rick McCallum and George Lucas;
+2000;Battlefield Earth;Warner Bros., Franchise Pictures;Jonathan D. Krane, Elie Samaha and John Travolta;yes
+2000;Book of Shadows: Blair Witch 2;Artisan Entertainment;Bill Carraro;
+2000;The Flintstones in Viva Rock Vegas;Universal Studios;Bruce Cohen;
+2000;Little Nicky;New Line Cinema;Jack Giarraputo and Robert Simonds;
+2000;The Next Best Thing;Paramount Pictures;Leslie Dixon, Linne Radmin and Tom Rosenberg;
+2001;Freddy Got Fingered;20th Century Fox;Larry Brezner, Howard Lapides and Lauren Lloyd;yes
+2001;Driven;Warner Bros., Franchise Pictures;Renny Harlin, Elie Samaha and Sylvester Stallone;
+2001;Glitter;20th Century Fox, Columbia Pictures;Laurence Mark and E. Bennett Walsh;
+2001;Pearl Harbor;Touchstone Pictures;Michael Bay and Jerry Bruckheimer;
+2001;3000 Miles to Graceland;Warner Bros., Franchise Pictures;Demian Lichtenstein, Eric Manes, Elie Samaha, Richard Spero and Andrew Stevens;
+2002;Swept Away;Screen Gems;Matthew Vaughn;yes
+2002;The Adventures of Pluto Nash;Warner Bros.;Martin Bregman, Michael Scott Bregman and Louis A. Stroller;
+2002;Crossroads;Paramount Pictures;Ann Carli;
+2002;Pinocchio;Miramax Films;Gianluigi Braschi, Nicoletta Braschi and Elda Ferri;
+2002;Star Wars: Episode II – Attack of the Clones;20th Century Fox;Rick McCallum and George Lucas;
+2003;Gigli;Columbia Pictures, Revolution Studios;Martin Brest and Casey Silver;yes
+2003;The Cat in the Hat;Universal Studios, DreamWorks;Brian Grazer;
+2003;Charlie's Angels: Full Throttle;Columbia Pictures;Drew Barrymore, Leonard Goldberg and Nancy Juvonen;
+2003;From Justin to Kelly;20th Century Fox;John Steven Agoglia;
+2003;The Real Cancun;New Line Cinema;Mary-Ellis Bunim, Jonathan Murray, Jamie Schutz and Rick de Oliveira;
+2004;Catwoman;Warner Bros.;Denise Di Novi and Edward McDonnell;yes
+2004;Alexander;Warner Bros.;Moritz Borman, Jon Kilik, Thomas Schuhly and Iain Smith;
+2004;Superbabies: Baby Geniuses 2;Triumph Films;Steven Paul;
+2004;Surviving Christmas;DreamWorks;Betty Thomas and Jenno Topping;
+2004;White Chicks;Columbia Pictures, Revolution Studios;Rick Alvarez, Lee R. Mayes, Keenen Ivory Wayans, Marlon Wayans and Shawn Wayans;
+2005;Dirty Love;First Look Pictures;John Mallory Asher, BJ Davis, Rod Hamilton, Kimberley Kates, Michael Manasseri, Jenny McCarthy and Trent Walford;yes
+2005;Deuce Bigalow: European Gigolo;Columbia Pictures;Adam Sandler and Rob Schneider;
+2005;The Dukes of Hazzard;Warner Bros., Village Roadshow;Bill Gerber;
+2005;House of Wax;Warner Bros., Village Roadshow;Susan Levin, Joel Silver and Robert Zemeckis;
+2005;Son of the Mask;New Line Cinema;Erica Huggins and Scott Kroopf;
+2006;Basic Instinct 2;MGM, C2 Pictures;Mario Kassar, Joel B. Michaels and Andrew G. Vajna;yes
+2006;BloodRayne;Romar Entertainment;Uwe Boll, Dan Clarke and Wolfgang Herrold;
+2006;Lady in the Water;Warner Bros.;Sam Mercer, Jose L. Rodriguez and M. Night Shyamalan;
+2006;Little Man;Columbia Pictures, Revolution Studios;Rick Alvares, Lee Mays, Marlon Wayans and Shawn Wayans;
+2006;The Wicker Man;Warner Bros.;Nicolas Cage, Randall Emmett, Norm Golightly, Avi Lerner and Joanne Sellar;
+2007;I Know Who Killed Me;TriStar Pictures;David Grace and Frank Mancuso Jr.;
+2007;Bratz;Lionsgate;Avi Arad, Isaac Larian and Steven Paul;
+2007;Daddy Day Camp;TriStar Pictures, Revolution Studios;Matt Berenson, John Davis and Wyck Godfrey;
+2007;I Now Pronounce You Chuck & Larry;Universal Studios;Adam Sandler and Tom Shadyac;
+2007;Norbit;DreamWorks;John Davis, Eddie Murphy and Michael Tollin;
+2008;The Love Guru;Paramount Pictures;Gary Barber, Michael DeLuca and Mike Myers;yes
+2008;Disaster Movie and Meet the Spartans;Lionsgate, 20th Century Fox;Jason Friedberg, Peter Safran and Aaron Seltzer;
+2008;The Happening;20th Century Fox;Barry Mendel, Sam Mercer and M. Night Shyamalan;
+2008;The Hottie & the Nottie;Regent Releasing;Hadeel Reda;
+2008;In the Name of the King;Boll KG, Brightlight Pictures;Uwe Boll, Dan Clarke, Wolfgang Herrold and Shawn Williamson;
+2009;Transformers: Revenge of the Fallen;Paramount Pictures, DreamWorks, Hasbro;Lorenzo di Bonaventura, Ian Bryce, Tom DeSanto and Don Murphy;yes
+2009;All About Steve;20th Century Fox;Sandra Bullock and Mary McLaglen;
+2009;G.I. Joe: The Rise of Cobra;Paramount Pictures, Hasbro;Lorenzo di Bonaventura, Bob Ducsay and Brian Goldner;
+2009;Land of the Lost;Universal Studios;Sid and Marty Krofft and Jimmy Miller;
+2009;Old Dogs;Walt Disney Pictures;Peter Abrams, Robert Levy and Andrew Panay;
+2010;The Last Airbender;Paramount Pictures, Nickelodeon Movies;Frank Marshall, Kathleen Kennedy, Sam Mercer and M. Night Shyamalan;yes
+2010;The Bounty Hunter;Columbia Pictures;Neal H. Moritz;
+2010;Sex and the City 2;New Line Cinema, HBO Films, Village Roadshow Pictures;Michael Patrick King, John Melfi, Sarah Jessica Parker and Darren Star;
+2010;The Twilight Saga: Eclipse;Summit Entertainment;Wyck Godfrey and Karen Rosenfelt;
+2010;Vampires Suck;20th Century Fox;Jason Friedberg, Peter Safran and Aaron Seltzer;
+2011;Jack and Jill;Columbia Pictures;Todd Garner, Jack Giarraputo and Adam Sandler;yes
+2011;Bucky Larson: Born to Be a Star;Columbia Pictures;Barry Bernardi, Allen Covert, David Dorfman and Jack Giarraputo;
+2011;New Year's Eve;Warner Bros., New Line Cinema;Mike Karz, Garry Marshall and Wayne Allan Rice;
+2011;Transformers: Dark of the Moon;Paramount Pictures;Lorenzo di Bonaventura, Ian Bryce, Tom DeSanto and Don Murphy;
+2011;The Twilight Saga: Breaking Dawn – Part 1;Summit Entertainment;Wyck Godfrey, Stephenie Meyer and Karen Rosenfelt;
+2012;The Twilight Saga: Breaking Dawn – Part 2;Summit Entertainment;Wyck Godfrey, Stephenie Meyer and Karen Rosenfelt;yes
+2012;Battleship;Universal Studios;Sarah Aubrey, Peter Berg, Brian Goldner, Duncan Henderson, Bennett Schneir and Scott Stuber;
+2012;The Oogieloves in the Big Balloon Adventure;Lionsgate Films, Romar Entertainment, Kenn Viselman Presents;Gayle Dickie, Kenn Viselman;
+2012;That's My Boy;Columbia Pictures;Allen Covert, Jack Giarraputo, Heather Parry and Adam Sandler;
+2012;A Thousand Words;Paramount Pictures, DreamWorks;Nicolas Cage, Alain Chabat, Stephanie Danan, Norman Golightly, Brian Robbinsand Sharla Sumpter Bridgett;
+2013;Movie 43;Relativity Media;Peter Farrelly, Ryan Kavanaugh, John Penotti and Charles B. Wessler;yes
+2013;After Earth;Columbia Pictures;James Lassiter, Caleeb Pinkett, Jada Pinkett Smith, M. Night Shyamalan, Will Smith and Jaden Smith;
+2013;Grown Ups 2;Columbia Pictures;Jack Giarraputo and Adam Sandler;
+2013;The Lone Ranger;Walt Disney Pictures;Jerry Bruckheimer and Gore Verbinski;
+2013;A Madea Christmas;Lionsgate;Ozzie Areu, Matt Moore and Tyler Perry;
+2014;Saving Christmas;Samuel Goldwyn Films;Darren Doane, Raphi Henley, Amanda Rosser and David Shannon;yes
+2014;Left Behind;Freestyle Releasing, Entertainment One;Michael Walker and Paul LaLonde;
+2014;The Legend of Hercules;Summit Entertainment;Boaz Davidson, Renny Harlin, Danny Lerner and Les Weldon;
+2014;Teenage Mutant Ninja Turtles;Paramount Pictures, Nickelodeon Movies, Platinum Dunes;Michael Bay, Ian Bryce, Andrew Form, Bradley Fuller, Scott Mednick and Galen Walker;
+2014;Transformers: Age of Extinction;Paramount Pictures;Ian Bryce, Tom DeSanto, Lorenzo di Bonaventura and Don Murphy;
+2015;Fantastic Four;20th Century Fox;Simon Kinberg, Matthew Vaughn, Hutch Parker, Robert Kulzer and Gregory Goodman;yes
+2015;Fifty Shades of Grey;Universal Pictures, Focus Features;Michael De Luca, Dana Brunetti and E. L. James;yes
+2015;Jupiter Ascending;Warner Bros.;Grant Hill and The Wachowskis;
+2015;Paul Blart: Mall Cop 2;Columbia Pictures;Todd Garner, Kevin James and Adam Sandler;
+2015;Pixels;Columbia Pictures;Adam Sandler, Chris Columbus, Mark Radcliffe and Allen Covert;
+2016;Hillary's America: The Secret History of the Democratic Party;Quality Flix;Gerald R. Molen;yes
+2016;Batman v Superman: Dawn of Justice;Warner Bros.;Charles Roven and Deborah Snyder;
+2016;Dirty Grandpa;Lionsgate;Bill Block, Michael Simkin, Jason Barrett and Barry Josephson;
+2016;Gods of Egypt;Summit Entertainment;Basil Iwanyk and Alex Proyas;
+2016;Independence Day: Resurgence;20th Century Fox;Dean Devlin, Harald Kloser and Roland Emmerich;
+2016;Zoolander 2;Paramount Pictures;Stuart Cornfeld, Scott Rudin, Ben Stiller and Clayton Townsend;
+2017;The Emoji Movie;Columbia Pictures;Michelle Raimo Kouyate;yes
+2017;Baywatch;Paramount Pictures;Ivan Reitman, Michael Berk, Douglas Schwartz, Gregory J. Bonann and Beau Flynn;
+2017;Fifty Shades Darker;Universal Pictures;Michael De Luca, E. L. James, Dana Brunetti and Marcus Viscidi;
+2017;The Mummy;Universal Pictures;Alex Kurtzman, Chris Morgan, Sean Daniel and Sarah Bradshaw;
+2017;Transformers: The Last Knight;Paramount Pictures;Don Murphy, Tom DeSanto, Lorenzo di Bonaventura and Ian Bryce;
+2018;Holmes & Watson;Columbia Pictures;Will Ferrell, Adam McKay, Jimmy Miller and Clayton Townsend;yes
+2018;Gotti;Vertical Entertainment;Randall Emmett, Marc Fiore, Michael Froch and George Furla;
+2018;The Happytime Murders;STX;Ben Falcone, Jeffrey Hayes, Brian Henson and Melissa McCarthy;
+2018;Robin Hood;Summit Entertainment;Jennifer Davisson and Leonardo DiCaprio;
+2018;Winchester;Lionsgate;Tim McGahan and Brett Tomberlin;
+2019;Cats;Universal Pictures;Debra Hayward, Tim Bevan, Eric Fellner, and Tom Hooper;yes
+2019;The Fanatic;Quiver Distribution;Daniel Grodnik, Oscar Generale, and Bill Kenwright;
+2019;The Haunting of Sharon Tate;Saban Films;Lucas Jarach, Daniel Farrands, and Eric Brenner;
+2019;A Madea Family Funeral;Lionsgate;Ozzie Areu, Will Areu, and Mark E. Swinton;
+2019;Rambo: Last Blood;Lionsgate;Avi Lerner, Kevin King Templeton, Yariv Lerner, and Les Weldon;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,10 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  clearMocks: true,
+  roots: ["<rootDir>/test"],
+  verbose: true,
+};
+export default config;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "test-otsra",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "node --no-warnings dist/index.js",
+    "build": "tsc -p .",
+    "test": "jest --runInBand"
+  },
+  "dependencies": {
+    "csv-parse": "^5.5.0",
+    "express": "^4.19.2",
+    "reflect-metadata": "^0.2.0",
+    "typeorm": "^0.3.19",
+    "sqlite3": "^5.1.6"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.5",
+    "@types/supertest": "^6.0.3",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.2",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.3"
+  }
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,15 @@
+import express from "express";
+import { movieRouter } from "./routes/movie.routes";
+import { producerRouter } from "./routes/producer.routes";
+
+export function createApp() {
+  const app = express();
+  app.use(express.json());
+
+  app.use("/movies", movieRouter);
+  app.use("/producers", producerRouter);
+
+  // healthcheck
+  app.get("/health", (_, res) => res.send("OK"));
+  return app;
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,11 @@
+import "reflect-metadata";
+import { DataSource } from "typeorm";
+import { Movie } from "./entities/Movie";
+
+export const AppDataSource = new DataSource({
+  type: "sqlite",
+  database: ":memory:",
+  synchronize: true,
+  entities: [Movie],
+  logging: false,
+});

--- a/src/entities/Movie.ts
+++ b/src/entities/Movie.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "typeorm";
+
+@Entity()
+export class Movie {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "int" })
+  year!: number;
+
+  @Column({ type: "varchar" })
+  title!: string;
+
+  @Column({ type: "varchar" })
+  producers!: string; // lista separada por vírgulas
+
+  @Column({ type: "boolean" })
+  winner!: boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import { parse } from "csv-parse";
+import { AppDataSource } from "./db";
+import { Movie } from "./entities/Movie";
+import { createApp } from "./app";
+
+await AppDataSource.initialize();
+
+// 1. importação do CSV → banco de dados
+const parser = fs.createReadStream("csv/Movielist.csv").pipe(
+  parse({
+    columns: true,
+    trim: true,
+    delimiter: ";", // CSV usa ponto‑e‑vírgula
+  })
+);
+
+for await (const record of parser) {
+  const movie = new Movie();
+  movie.year = +record.year;
+  movie.title = record.title;
+  movie.producers = record.producers;
+  movie.winner = record.winner.toLowerCase() === "yes";
+  await AppDataSource.manager.save(movie);
+}
+
+// 2. inicia o servidor HTTP
+const port = process.env.PORT ?? 3000;
+createApp().listen(port, () => {
+  console.log(`API escutando em http://localhost:${port}`);
+});

--- a/src/repositories/movie.repository.ts
+++ b/src/repositories/movie.repository.ts
@@ -1,0 +1,6 @@
+import { Repository } from "typeorm";
+import { Movie } from "../entities/Movie";
+import { AppDataSource } from "../db";
+
+export const movieRepository = (): Repository<Movie> =>
+  AppDataSource.getRepository(Movie);

--- a/src/routes/movie.routes.ts
+++ b/src/routes/movie.routes.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import { movieRepository } from "../repositories/movie.repository";
+
+export const movieRouter = Router();
+
+movieRouter.get("/", async (_, res) => {
+  const movies = await movieRepository().find();
+  res.json(movies);
+});
+
+movieRouter.get("/:id", async (req, res) => {
+  const movie = await movieRepository().findOneBy({ id: +req.params.id });
+  if (!movie) return res.sendStatus(404);
+  res.json(movie);
+});

--- a/src/routes/producer.routes.ts
+++ b/src/routes/producer.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { calculateIntervals } from "../services/interval.service";
+
+export const producerRouter = Router();
+
+producerRouter.get("/intervals", async (_, res) => {
+  const response = await calculateIntervals();
+  res.json(response);
+});

--- a/src/services/interval.service.ts
+++ b/src/services/interval.service.ts
@@ -1,0 +1,53 @@
+import { movieRepository } from "../repositories/movie.repository";
+
+export interface IntervalDTO {
+  producer: string;
+  interval: number;
+  previousWin: number;
+  followingWin: number;
+}
+
+export interface IntervalResponse {
+  min: IntervalDTO[];
+  max: IntervalDTO[];
+}
+
+export async function calculateIntervals(): Promise<IntervalResponse> {
+  const repo = movieRepository();
+  const winners = await repo.find({ where: { winner: true } });
+
+  // mapeia produtor → lista de anos em que venceu
+  const map = new Map<string, number[]>();
+  for (const w of winners) {
+    w.producers.split(/,\s*| and /i).forEach((p) => {
+      const list = map.get(p.trim()) ?? [];
+      list.push(w.year);
+      map.set(p.trim(), list);
+    });
+  }
+
+  // calcula intervalos por produtor
+  const intervals: IntervalDTO[] = [];
+  for (const [producer, years] of map.entries()) {
+    if (years.length < 2) continue;
+    const sorted = years.sort((a, b) => a - b);
+    for (let i = 1; i < sorted.length; i++) {
+      intervals.push({
+        producer,
+        interval: sorted[i] - sorted[i - 1],
+        previousWin: sorted[i - 1],
+        followingWin: sorted[i],
+      });
+    }
+  }
+
+  if (intervals.length === 0) return { min: [], max: [] };
+
+  const minValue = Math.min(...intervals.map((i) => i.interval));
+  const maxValue = Math.max(...intervals.map((i) => i.interval));
+
+  return {
+    min: intervals.filter((i) => i.interval === minValue),
+    max: intervals.filter((i) => i.interval === maxValue),
+  };
+}

--- a/test/movie.e2e.spec.ts
+++ b/test/movie.e2e.spec.ts
@@ -1,0 +1,31 @@
+import request from "supertest";
+import { createApp } from "../src/app";
+import { AppDataSource } from "../src/db";
+import { Movie } from "../src/entities/Movie";
+import { calculateIntervals } from "../src/services/interval.service";
+
+beforeAll(async () => {
+  await AppDataSource.initialize();
+  await AppDataSource.manager.save(
+    AppDataSource.manager.create(Movie, [
+      { year: 2000, title: "Foo", producers: "A", winner: true },
+      { year: 2005, title: "Bar", producers: "A", winner: true },
+      { year: 2001, title: "Baz", producers: "B", winner: true },
+      { year: 2010, title: "Qux", producers: "B", winner: true },
+    ])
+  );
+});
+
+afterAll(() => AppDataSource.destroy());
+
+const app = createApp();
+
+describe("GET /producers/intervals", () => {
+  it("deve retornar os intervalos mínimos e máximos corretos", async () => {
+    const res = await request(app).get("/producers/intervals");
+    expect(res.status).toBe(200);
+
+    // serviço e rota devem concordar
+    expect(res.body).toEqual(await calculateIntervals());
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "outDir": "dist",
+    "types": ["node", "jest"]
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
### 📑 Pull Request — “MVP API Pior Filme do Framboesa de Ouro (TypeScript)”

> _Implementa uma API REST em nível 2 de maturidade Richardson que carrega o conjunto de dados “Pior Filme” do Framboesa de Ouro a partir de um CSV para um banco SQLite em memória e expõe estatísticas de filmes e produtores._

---

## ✨ Novidades

| Área | Detalhes |
|------|----------|
| **Ingestão de dados** | • Loader de CSV (`delimiter: ';'`) executado no bootstrap e persiste linhas como entidades `Movie` via TypeORM.<br>• Novo `csv/Movielist.csv` com a lista completa atualizada até 2019. |
| **Persistência** | • Fonte de dados SQLite **`:memory:`** (sem BD externo). |
| **Modelo de domínio** | • Entidade `Movie` (`id`, `year`, `title`, `producers`, `winner`). |
| **Rotas (REST nível 2)** | • `GET /movies` – lista todos os filmes.<br>• `GET /movies/:id` – busca filme por PK.<br>• `GET /producers/intervals` – retorna intervalos mín./máx. de vitórias por produtor (contrato do desafio). |
| **Camada de serviço** | • `interval.service.ts` calcula os gaps consecutivos por produtor e devolve `{ min, max }`. |
| **Testes** | • Testes de integração com **Jest + SuperTest** (`test/movie.e2e.spec.ts`).<br>• Cria BD em memória isolado, insere fixtures, faz requisição HTTP real e valida JSON exato. |
| **Ferramentas** | • Runner dev com **tsx watch** (`npm run dev`).<br>• Script de build → `dist/` (`npm run build`). |
| **Documentação** | • **README** completo (badges, features, setup, contrato da API, estrutura).<br>• `.gitignore` ignora `node_modules`, artefatos de build e arquivos de lock (`package-lock.json`). |
| **Manutenções** | • Ajustadas versões ausentes (`supertest@^6.3.4`, `ts-node@^10.9.2`).<br>• Adicionada dependência de runtime `sqlite3@^5.1.6`.<br>• Arquivos `.env` exemplares ignorados. |

---

## 🏗️ Como testar localmente

```bash
npm i          # instala dependências
npm run dev    # sobe a API em http://localhost:3000
npm t          # executa suíte de integração (Jest --runInBand)
